### PR TITLE
[6] [feat] Clean gradle implementations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,22 +40,8 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
+    implementation(libs.bundles.layer.presentation)
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 
     implementation(project(":designsystem"))
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -33,11 +33,5 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
+    testImplementation(libs.bundles.testing.unit)
 }

--- a/designsystem/build.gradle.kts
+++ b/designsystem/build.gradle.kts
@@ -36,20 +36,6 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
+    implementation(libs.bundles.layer.presentation)
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -33,11 +33,5 @@ android {
 }
 
 dependencies {
-
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
+    testImplementation(libs.bundles.testing.unit)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.03.01"
-appcompat = "1.7.0"
 material = "1.12.0"
 
 [libraries]
@@ -23,10 +22,7 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [plugins]
@@ -35,3 +31,23 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 
+[bundles]
+layer-presentation = [
+    "androidx-activity-compose",
+    "androidx-core-ktx",
+    "androidx-lifecycle-runtime-ktx",
+    "androidx-ui",
+    "androidx-ui-graphics",
+    "androidx-ui-tooling",
+    "androidx-ui-tooling-preview",
+    "androidx-material3",
+    "material",
+]
+
+testing-instrumentation = [
+    "androidx-junit",
+    "androidx-espresso-core",
+]
+testing-unit = [
+    "junit",
+]


### PR DESCRIPTION
Closes #6 
This pull request includes several changes to the `build.gradle.kts` files and the `gradle/libs.versions.toml` file to streamline dependencies and organize them into bundles. The most important changes include the creation of dependency bundles for presentation and testing, and the removal of individual dependencies in favor of these bundles.

Dependency management improvements:

* `app/build.gradle.kts`, `designsystem/build.gradle.kts`: Replaced individual dependencies with `libs.bundles.layer.presentation` to group related dependencies. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L43-L58) [[2]](diffhunk://#diff-6e88fabf7c7779337ce6713c28b1d08483371a02d0ebde1319bc7d15eca174e3L39-L54)
* `data/build.gradle.kts`, `domain/build.gradle.kts`: Replaced individual testing dependencies with `libs.bundles.testing.unit` to group unit testing dependencies. [[1]](diffhunk://#diff-d2805d83e69c4c4d37fbacc9f7f2f95fb0e10310cf588d44510c6c6cf40207beL36-R36) [[2]](diffhunk://#diff-d2805d83e69c4c4d37fbacc9f7f2f95fb0e10310cf588d44510c6c6cf40207beL36-R36)

Dependency bundle definitions:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR34-R53): Defined new bundles `layer-presentation`, `testing-instrumentation`, and `testing-unit` to group related dependencies and simplify dependency management.

Removal of unused dependencies:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL26-L29): Removed unused dependency definitions such as `androidx-appcompat` and `androidx-ui-test-manifest`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL26-L29) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL11)