### PR TITLE
[16] [feat] Implement data layer and simulate api call

### DIFF
--- a/.github/workflows/check-code-coverage.yml
+++ b/.github/workflows/check-code-coverage.yml
@@ -58,22 +58,6 @@ jobs:
             echo "" >> report.md
             echo "⚠️ **Coverage data not found!**" >> report.md
           fi
-
-          echo "" >> report.md
-          echo "📊 **Coverage per Module**" >> report.md
-
-          modules=$(grep -oP '(?<=name=")[^"]+' app/build/reports/kover/reportDebug.xml)
-          for module in $modules; do
-            module_covered=$(grep -oP "(?<=name=\"$module\" covered=\")\d+" app/build/reports/kover/reportDebug.xml)
-            module_missed=$(grep -oP "(?<=name=\"$module\" missed=\")\d+" app/build/reports/kover/reportDebug.xml)
-            module_instructions=$((module_covered + module_missed))
-
-            if [[ $module_instructions -gt 0 ]]; then
-              module_coverage_percentage=$((100 * module_covered / module_instructions))
-              echo "- **$module**: $module_coverage_percentage%" >> report.md
-            else
-              echo "- **$module**: ⚠️ Coverage data not found!" >> report.md
-            fi
           done
 
       - name: Post report as PR comment

--- a/.github/workflows/check-code-coverage.yml
+++ b/.github/workflows/check-code-coverage.yml
@@ -58,7 +58,6 @@ jobs:
             echo "" >> report.md
             echo "⚠️ **Coverage data not found!**" >> report.md
           fi
-          done
 
       - name: Post report as PR comment
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/check-code-coverage.yml
+++ b/.github/workflows/check-code-coverage.yml
@@ -1,4 +1,4 @@
-name: Check Tests
+name: Check Code Coverage
 
 on:
   pull_request:
@@ -32,9 +32,12 @@ jobs:
         run: ./gradlew :app:testDebugUnitTest
         continue-on-error: true
 
-      - name: Post test results to PR
+      - name: Generate kover coverage report
+        run: ./gradlew :app:koverXmlReportDebug
+
+      - name: Calculate test results and coverage
         run: |
-          echo "### 📝 Test Report" > report.md
+          echo "### 📝 Test & Coverage Report" > report.md
           echo "" >> report.md
           
           if [[ "${{ steps.run_tests.outcome }}" == "failure" ]]; then
@@ -42,6 +45,36 @@ jobs:
           else
             echo "✅ **All tests passed!**" >> report.md
           fi
+
+          total_covered=$(grep -oP '(?<=covered=")\d+' app/build/reports/kover/reportDebug.xml | paste -sd+ | bc)
+          total_missed=$(grep -oP '(?<=missed=")\d+' app/build/reports/kover/reportDebug.xml | paste -sd+ | bc)
+          total_instructions=$((total_covered + total_missed))
+
+          if [[ $total_instructions -gt 0 ]]; then
+            coverage_percentage=$((100 * total_covered / total_instructions))
+            echo "" >> report.md
+            echo "📊 **Total Code Coverage: $coverage_percentage%**" >> report.md
+          else
+            echo "" >> report.md
+            echo "⚠️ **Coverage data not found!**" >> report.md
+          fi
+
+          echo "" >> report.md
+          echo "📊 **Coverage per Module**" >> report.md
+
+          modules=$(grep -oP '(?<=name=")[^"]+' app/build/reports/kover/reportDebug.xml)
+          for module in $modules; do
+            module_covered=$(grep -oP "(?<=name=\"$module\" covered=\")\d+" app/build/reports/kover/reportDebug.xml)
+            module_missed=$(grep -oP "(?<=name=\"$module\" missed=\")\d+" app/build/reports/kover/reportDebug.xml)
+            module_instructions=$((module_covered + module_missed))
+
+            if [[ $module_instructions -gt 0 ]]; then
+              module_coverage_percentage=$((100 * module_covered / module_instructions))
+              echo "- **$module**: $module_coverage_percentage%" >> report.md
+            else
+              echo "- **$module**: ⚠️ Coverage data not found!" >> report.md
+            fi
+          done
 
       - name: Post report as PR comment
         uses: mshick/add-pr-comment@v2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,4 +87,8 @@ dependencies {
     implementation(project(":common:di"))
     implementation(project(":designsystem"))
     implementation(project(":presentation"))
+
+    // Impl for kover merging reports on this root module
+    kover(project(":domain"))
+    kover(project(":data"))
 }

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSource.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.adrifernandev.marsroverchallenge.data.datasource.remote
+
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+import kotlinx.coroutines.flow.Flow
+
+interface RoverRemoteDataSource {
+    fun getRoverInput(): Flow<Result<RoverInstructionsDTO>>
+}

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSourceImpl.kt
@@ -1,0 +1,21 @@
+package com.adrifernandev.marsroverchallenge.data.datasource.remote
+
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.service.RoverService
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RoverRemoteDataSourceImpl @Inject constructor(
+    private val roverService: RoverService
+) : RoverRemoteDataSource {
+
+    override fun getRoverInput(): Flow<Result<RoverInstructionsDTO>> = flow {
+        try {
+            val dto = roverService.getRoverInput()
+            emit(Result.success(dto))
+        } catch (e: Exception) {
+            emit(Result.failure(e))
+        }
+    }
+}

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/RoverService.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/RoverService.kt
@@ -1,0 +1,7 @@
+package com.adrifernandev.marsroverchallenge.data.datasource.remote.service
+
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+
+interface RoverService {
+    suspend fun getRoverInput(): RoverInstructionsDTO
+}

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/RoverServiceImpl.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/RoverServiceImpl.kt
@@ -1,0 +1,26 @@
+package com.adrifernandev.marsroverchallenge.data.datasource.remote.service
+
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.service.generator.generateRandomRoverInputJson
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+private const val MIN_DELAY_TIME_LONG = 500L
+private const val MAX_DELAY_TIME_LONG = 2000L
+
+class RoverServiceImpl @Inject constructor(
+    private val json: Json,
+) : RoverService {
+
+    override suspend fun getRoverInput(): RoverInstructionsDTO {
+        val randomDelay = (MIN_DELAY_TIME_LONG..MAX_DELAY_TIME_LONG).random()
+        delay(randomDelay)
+        return try {
+            val jsonInput = generateRandomRoverInputJson()
+            json.decodeFromString<RoverInstructionsDTO>(jsonInput)
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+}

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/generator/RoverDataGenerator.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/generator/RoverDataGenerator.kt
@@ -1,13 +1,18 @@
 package com.adrifernandev.marsroverchallenge.data.datasource.remote.service.generator
 
 import com.adrifernandev.marsroverchallenge.domain.models.Direction
-import kotlin.random.Random
+
+private const val MIN_POSITION = 0
+private const val MIN_TOP = 5
+private const val MAX_TOP = 10
+private const val MIN_MOVEMENTS = 5
+private const val MAX_MOVEMENTS = 11
 
 fun generateRandomRoverInputJson(): String {
-    val maxX = Random.nextInt(5, 11)
-    val maxY = Random.nextInt(5, 11)
-    val startX = Random.nextInt(0, maxX + 1)
-    val startY = Random.nextInt(0, maxY + 1)
+    val maxX = (MIN_TOP..MAX_TOP).random()
+    val maxY = (MIN_TOP..MAX_TOP).random()
+    val startX = (MIN_POSITION..maxX).random()
+    val startY = (MIN_POSITION..maxY).random()
     val direction = Direction.entries.toTypedArray().random().name
     val movements = generateRandomMovements()
 
@@ -28,9 +33,9 @@ fun generateRandomRoverInputJson(): String {
 }
 
 private fun generateRandomMovements(): String {
-    val length = Random.nextInt(5, 11)
+    val length = (MIN_MOVEMENTS..MAX_MOVEMENTS).random()
     return List(length) {
-        when (Random.nextInt(0, 3)) {
+        when ((0..3).random()) {
             0 -> "L"
             1 -> "R"
             else -> "M"

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/generator/RoverDataGenerator.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/generator/RoverDataGenerator.kt
@@ -1,0 +1,39 @@
+package com.adrifernandev.marsroverchallenge.data.datasource.remote.service.generator
+
+import com.adrifernandev.marsroverchallenge.domain.models.Direction
+import kotlin.random.Random
+
+fun generateRandomRoverInputJson(): String {
+    val maxX = Random.nextInt(5, 11)
+    val maxY = Random.nextInt(5, 11)
+    val startX = Random.nextInt(0, maxX + 1)
+    val startY = Random.nextInt(0, maxY + 1)
+    val direction = Direction.entries.toTypedArray().random().name
+    val movements = generateRandomMovements()
+
+    return """
+            {
+                "topRightCorner": {
+                    "x": $maxX,
+                    "y": $maxY
+                },
+                "roverPosition": {
+                    "x": $startX,
+                    "y": $startY
+                },
+                "roverDirection": "$direction",
+                "movements": "$movements"
+            }
+        """.trimIndent()
+}
+
+private fun generateRandomMovements(): String {
+    val length = Random.nextInt(5, 11)
+    return List(length) {
+        when (Random.nextInt(0, 3)) {
+            0 -> "L"
+            1 -> "R"
+            else -> "M"
+        }
+    }.joinToString("")
+}

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/di/DataModule.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/di/DataModule.kt
@@ -1,11 +1,16 @@
 package com.adrifernandev.marsroverchallenge.data.di
 
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.RoverRemoteDataSource
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.RoverRemoteDataSourceImpl
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.service.RoverService
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.service.RoverServiceImpl
 import com.adrifernandev.marsroverchallenge.data.repository.RoverRepositoryImpl
 import com.adrifernandev.marsroverchallenge.domain.repository.RoverRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
 import javax.inject.Singleton
 
 @Module
@@ -14,7 +19,31 @@ object DataModule {
 
     @Provides
     @Singleton
-    fun provideMarsRoverRepository(): RoverRepository {
-        return RoverRepositoryImpl()
+    fun provideMarsRoverRepository(
+        roverRemoteDataSource: RoverRemoteDataSource
+    ): RoverRepository {
+        return RoverRepositoryImpl(roverRemoteDataSource)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRoverRemoteDataSource(
+        roverService: RoverService
+    ): RoverRemoteDataSource {
+        return RoverRemoteDataSourceImpl(roverService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRoverService(
+        json: Json
+    ): RoverService {
+        return RoverServiceImpl(json)
+    }
+
+    @Provides
+    @Singleton
+    fun providesJson(): Json {
+        return Json { ignoreUnknownKeys = true }
     }
 }

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/dto/PositionDTO.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/dto/PositionDTO.kt
@@ -1,0 +1,12 @@
+package com.adrifernandev.marsroverchallenge.data.dto
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PositionDTO(
+    @SerializedName("x")
+    val x: Int,
+    @SerializedName("y")
+    val y: Int
+)

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/dto/RoverDTO.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/dto/RoverDTO.kt
@@ -1,0 +1,16 @@
+package com.adrifernandev.marsroverchallenge.data.dto
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RoverInstructionsDTO(
+    @SerializedName("topRightCorner")
+    val topRightCorner: PositionDTO,
+    @SerializedName("roverPosition")
+    val roverPosition: PositionDTO,
+    @SerializedName("roverDirection")
+    val roverDirection: String,
+    @SerializedName("movements")
+    val movements: String,
+)

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt
@@ -1,0 +1,35 @@
+package com.adrifernandev.marsroverchallenge.data.mapper
+
+import com.adrifernandev.marsroverchallenge.data.dto.PositionDTO
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+import com.adrifernandev.marsroverchallenge.domain.models.Direction
+import com.adrifernandev.marsroverchallenge.domain.models.Instructions
+import com.adrifernandev.marsroverchallenge.domain.models.Plateau
+import com.adrifernandev.marsroverchallenge.domain.models.Position
+import com.adrifernandev.marsroverchallenge.domain.models.Rover
+import com.adrifernandev.marsroverchallenge.domain.models.RoverInput
+
+fun RoverInstructionsDTO.toDomain(): RoverInput {
+    return RoverInput(
+        plateau = this.topRightCorner.toPlateau(),
+        initialRover = toRover(this.roverPosition, this.roverDirection),
+        instructions = Instructions.fromString(this.movements)
+    )
+}
+
+private fun PositionDTO.toPlateau(): Plateau {
+    require(this.x >= 0 && this.y >= 0) { "Plateau dimensions must be non-negative" }
+    return Plateau(Position(this.x, this.y))
+}
+
+private fun toRover(positionDTO: PositionDTO, direction: String): Rover {
+    require(positionDTO.x >= 0 && positionDTO.y >= 0) { "Rover position must be non-negative" }
+    return Rover(
+        currentPosition = Position(positionDTO.x, positionDTO.y),
+        currentDirection = try {
+            Direction.valueOf(direction)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Invalid rover direction: $direction")
+        }
+    )
+}

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt
@@ -17,12 +17,12 @@ fun RoverInstructionsDTO.toDomain(): RoverInput {
     )
 }
 
-private fun PositionDTO.toPlateau(): Plateau {
+fun PositionDTO.toPlateau(): Plateau {
     require(this.x >= 0 && this.y >= 0) { "Plateau dimensions must be non-negative" }
     return Plateau(Position(this.x, this.y))
 }
 
-private fun toRover(positionDTO: PositionDTO, direction: String): Rover {
+fun toRover(positionDTO: PositionDTO, direction: String): Rover {
     require(positionDTO.x >= 0 && positionDTO.y >= 0) { "Rover position must be non-negative" }
     return Rover(
         currentPosition = Position(positionDTO.x, positionDTO.y),

--- a/data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSourceImplTest.kt
+++ b/data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSourceImplTest.kt
@@ -1,0 +1,52 @@
+package com.adrifernandev.marsroverchallenge.data.datasource.remote
+
+import app.cash.turbine.test
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.service.RoverService
+import com.adrifernandev.marsroverchallenge.data.dto.PositionDTO
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RoverRemoteDataSourceImplTest {
+
+    private val roverService: RoverService = mockk()
+    private val dataSource = RoverRemoteDataSourceImpl(roverService)
+
+    @Test
+    fun `getRoverInput should emit success when service returns valid DTO`() = runTest {
+        // Given
+        val dto = RoverInstructionsDTO(
+            topRightCorner = PositionDTO(x = 5, y = 5),
+            roverPosition = PositionDTO(x = 1, y = 2),
+            roverDirection = "N",
+            movements = "LMLMLMLMM"
+        )
+        coEvery { roverService.getRoverInput() } returns dto
+
+        // When
+        dataSource.getRoverInput().test {
+            // Then
+            val result = awaitItem()
+            assertEquals(Result.success(dto), result)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `getRoverInput should emit failure when service throws exception`() = runTest {
+        // Given
+        val exception = RuntimeException("Service failed")
+        coEvery { roverService.getRoverInput() } throws exception
+
+        // When
+        dataSource.getRoverInput().test {
+            // Then
+            val result = awaitItem()
+            assertEquals(Result.failure<RoverInstructionsDTO>(exception), result)
+            awaitComplete()
+        }
+    }
+}

--- a/data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapperTest.kt
+++ b/data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapperTest.kt
@@ -1,0 +1,96 @@
+package com.adrifernandev.marsroverchallenge.data.mapper
+
+import com.adrifernandev.marsroverchallenge.data.dto.PositionDTO
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+import com.adrifernandev.marsroverchallenge.domain.models.Direction
+import com.adrifernandev.marsroverchallenge.domain.models.Instructions
+import com.adrifernandev.marsroverchallenge.domain.models.Plateau
+import com.adrifernandev.marsroverchallenge.domain.models.Position
+import com.adrifernandev.marsroverchallenge.domain.models.Rover
+import com.adrifernandev.marsroverchallenge.domain.models.RoverInput
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class RoverMapperTest {
+
+    @Test
+    fun `toDomain should map RoverInstructionsDTO to RoverInput correctly`() {
+        // Given
+        val dto = RoverInstructionsDTO(
+            topRightCorner = PositionDTO(x = 5, y = 5),
+            roverPosition = PositionDTO(x = 1, y = 2),
+            roverDirection = "N",
+            movements = "LMLMLMLMM"
+        )
+        val expected = RoverInput(
+            plateau = Plateau(Position(5, 5)),
+            initialRover = Rover(Position(1, 2), Direction.N),
+            instructions = Instructions.fromString("LMLMLMLMM")
+        )
+
+        // When
+        val result = dto.toDomain()
+
+        // Then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `toPlateau should throw IllegalArgumentException for negative dimensions`() {
+        // Given
+        val dto = PositionDTO(x = -1, y = 5)
+
+        // When
+        val exception = assertFailsWith<IllegalArgumentException> {
+            dto.toPlateau()
+        }
+
+        // Then
+        assertEquals("Plateau dimensions must be non-negative", exception.message)
+    }
+
+    @Test
+    fun `toRover should map PositionDTO and direction correctly`() {
+        // Given
+        val positionDto = PositionDTO(x = 3, y = 4)
+        val direction = "E"
+        val expected = Rover(Position(3, 4), Direction.E)
+
+        // When
+        val result = toRover(positionDto, direction)
+
+        // Then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `toRover should throw IllegalArgumentException for negative position`() {
+        // Given
+        val positionDto = PositionDTO(x = -1, y = 2)
+        val direction = "N"
+
+        // When
+        val exception = assertFailsWith<IllegalArgumentException> {
+            toRover(positionDto, direction)
+        }
+
+        // Then
+        assertEquals("Rover position must be non-negative", exception.message)
+    }
+
+    @Test
+    fun `toRover should throw IllegalArgumentException for invalid direction`() {
+        // Given
+        val positionDto = PositionDTO(x = 1, y = 2)
+        val direction = "X"
+
+        // When
+        val exception = assertFailsWith<IllegalArgumentException> {
+            toRover(positionDto, direction)
+        }
+
+        // Then
+        assertEquals("Invalid rover direction: X", exception.message)
+    }
+}

--- a/data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/repository/RoverRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/repository/RoverRepositoryImplTest.kt
@@ -1,0 +1,65 @@
+package com.adrifernandev.marsroverchallenge.data.repository
+
+import app.cash.turbine.test
+import com.adrifernandev.marsroverchallenge.data.datasource.remote.RoverRemoteDataSource
+import com.adrifernandev.marsroverchallenge.data.dto.PositionDTO
+import com.adrifernandev.marsroverchallenge.data.dto.RoverInstructionsDTO
+import com.adrifernandev.marsroverchallenge.domain.models.Direction
+import com.adrifernandev.marsroverchallenge.domain.models.Instructions
+import com.adrifernandev.marsroverchallenge.domain.models.Plateau
+import com.adrifernandev.marsroverchallenge.domain.models.Position
+import com.adrifernandev.marsroverchallenge.domain.models.Rover
+import com.adrifernandev.marsroverchallenge.domain.models.RoverInput
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RoverRepositoryImplTest {
+
+    private val roverRemoteDataSource: RoverRemoteDataSource = mockk()
+    private val repository = RoverRepositoryImpl(roverRemoteDataSource)
+
+    @Test
+    fun `getRoverInstructions should emit mapped RoverInput when data source returns success`() =
+        runTest {
+            // Given
+            val dto = RoverInstructionsDTO(
+                topRightCorner = PositionDTO(x = 5, y = 5),
+                roverPosition = PositionDTO(x = 1, y = 2),
+                roverDirection = "N",
+                movements = "LMLMLMLMM"
+            )
+            val expectedRoverInput = RoverInput(
+                plateau = Plateau(Position(5, 5)),
+                initialRover = Rover(Position(1, 2), Direction.N),
+                instructions = Instructions.fromString("LMLMLMLMM")
+            )
+            every { roverRemoteDataSource.getRoverInput() } returns flowOf(Result.success(dto))
+
+            // When
+            repository.getRoverInstructions().test {
+                // Then
+                val result = awaitItem()
+                assertEquals(Result.success(expectedRoverInput), result)
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun `getRoverInstructions should emit failure when data source returns failure`() = runTest {
+        // Given
+        val exception = RuntimeException("Data source failed")
+        every { roverRemoteDataSource.getRoverInput() } returns flowOf(Result.failure(exception))
+
+        // When
+        repository.getRoverInstructions().test {
+            // Then
+            val result = awaitItem()
+            assertEquals(Result.failure<RoverInput>(exception), result)
+            awaitComplete()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ hiltCompose = "1.2.0"
 ksp = "2.0.20-1.0.24"
 kotlinxCoroutinesTest = "1.8.1"
 turbine = "1.1.0"
+gson = "2.10.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -57,6 +58,8 @@ com-google-dagger-hilt-compose = { module = "androidx.hilt:hilt-navigation-compo
 org-jetbrains-kotlinx-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 
 app-cash-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+
+com-google-code-gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -95,6 +98,7 @@ layer-data = [
     "androidx-lifecycle-runtime-ktx",
     "kotlinx-serialization-json",
     "com-google-dagger-hilt-android",
+    "com-google-code-gson",
 ]
 
 compilers-ksp-generic = [


### PR DESCRIPTION
Resolve #16 

This pull request introduces significant changes to the codebase, focusing on adding code coverage checks, implementing a new remote data source for the Mars Rover challenge, and adding necessary dependencies and tests. The most important changes include modifications to the GitHub Actions workflow, the creation of new data source and service classes, and the addition of new DTOs and mappers.

### GitHub Actions Workflow:
* [`.github/workflows/check-code-coverage.yml`](diffhunk://#diff-37768682a2ec8198cbf775dd973d66c66ace7ea03ac9d6a6acbc2fc756c14ee7L1-R1): Updated the workflow to generate and calculate code coverage reports using `kover`. The workflow now includes steps to generate the coverage report, calculate the total and per-module coverage, and post the results as a PR comment. [[1]](diffhunk://#diff-37768682a2ec8198cbf775dd973d66c66ace7ea03ac9d6a6acbc2fc756c14ee7L1-R1) [[2]](diffhunk://#diff-37768682a2ec8198cbf775dd973d66c66ace7ea03ac9d6a6acbc2fc756c14ee7L35-R40) [[3]](diffhunk://#diff-37768682a2ec8198cbf775dd973d66c66ace7ea03ac9d6a6acbc2fc756c14ee7R49-R78)

### Remote Data Source Implementation:
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSource.kt`](diffhunk://#diff-6e79cb07e5bcb104885d6cb5cff6d3de09c9d1751485599edd4d6fe7925161bdR1-R8): Added a new interface for the remote data source to fetch rover input data.
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSourceImpl.kt`](diffhunk://#diff-23d84ddeb95f7bb9df9b3a393c06e98dab03068d06b6ecf159dcf34bf64843e0R1-R21): Implemented the remote data source interface to fetch rover input data from the service.
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/RoverService.kt`](diffhunk://#diff-82a89375557fc50935cf19f5cdd9a577fcdb4fb6c81ce3231370b3b4d0f7edd1R1-R7): Added a new service interface to define the method for fetching rover input data.
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/RoverServiceImpl.kt`](diffhunk://#diff-47260f8982e787ccfd5151969d591837ab00c4703a750d16b1a2dd628abf8e53R1-R26): Implemented the service interface to provide rover input data, including generating random data for testing purposes.

### Dependency Injection:
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/di/DataModule.kt`](diffhunk://#diff-e2cf92ef21c5c0a901f7368b3080138b1a99dce5b5d8ddd8dc3afd097fb953a9R3-R13): Updated the DI module to provide instances of the new remote data source and service classes. [[1]](diffhunk://#diff-e2cf92ef21c5c0a901f7368b3080138b1a99dce5b5d8ddd8dc3afd097fb953a9R3-R13) [[2]](diffhunk://#diff-e2cf92ef21c5c0a901f7368b3080138b1a99dce5b5d8ddd8dc3afd097fb953a9L17-R47)

### Data Transfer Objects (DTOs) and Mappers:
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/dto/PositionDTO.kt`](diffhunk://#diff-16532f39c8860fba443cfe292d3c558e08ef0b412a01d5bf80cb07f7e813216cR1-R12): Added a new DTO for representing positions.
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/dto/RoverDTO.kt`](diffhunk://#diff-ddcd8d06c3999ac6679a98cfff6cbcea3d3f55f94f9da4409509a66a8c9eadd1R1-R16): Added a new DTO for representing rover instructions.
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt`](diffhunk://#diff-c7a82831f183dfa6ac5c6c754ddad2343d1635d473f82e49bce180068ec69e6eR1-R35): Added mappers to convert DTOs to domain models.

### Tests:
* [`data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/datasource/remote/RoverRemoteDataSourceImplTest.kt`](diffhunk://#diff-48ccfa2cebc0a9efe0b7235316bdb48939aba56f06c19f982d96e9a0453f62a1R1-R52): Added tests for the remote data source implementation to ensure correct behavior when fetching rover input data.
* [`data/src/test/kotlin/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapperTest.kt`](diffhunk://#diff-9011605a2cda69ca7eb908049ee767b1041c15d4eaa498cceba4cf75e5ae4befR1-R96): Added tests for the mappers to ensure correct conversion from DTOs to domain models.