### PR TITLE
[24] [feat] Handle wrong input

### DIFF
--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/generator/RoverDataGenerator.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/generator/RoverDataGenerator.kt
@@ -9,14 +9,15 @@ private const val MIN_MOVEMENTS = 5
 private const val MAX_MOVEMENTS = 11
 
 fun generateRandomRoverInputJson(): String {
-    val maxX = (MIN_TOP..MAX_TOP).random()
-    val maxY = (MIN_TOP..MAX_TOP).random()
-    val startX = (MIN_POSITION..maxX).random()
-    val startY = (MIN_POSITION..maxY).random()
-    val direction = Direction.entries.toTypedArray().random().name
-    val movements = generateRandomMovements()
+    try {
+        val maxX = (MIN_TOP..MAX_TOP).random()
+        val maxY = (MIN_TOP..MAX_TOP).random()
+        val startX = (MIN_POSITION..maxX).random()
+        val startY = (MIN_POSITION..maxY).random()
+        val direction = Direction.entries.toTypedArray().random().name
+        val movements = generateRandomMovements()
 
-    return """
+        return """
             {
                 "topRightCorner": {
                     "x": $maxX,
@@ -30,6 +31,9 @@ fun generateRandomRoverInputJson(): String {
                 "movements": "$movements"
             }
         """.trimIndent()
+    } catch (e: IllegalArgumentException) {
+        throw IllegalArgumentException("Invalid input data for rover generation: ${e.message}")
+    }
 }
 
 private fun generateRandomMovements(): String {

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt
@@ -10,11 +10,15 @@ import com.adrifernandev.marsroverchallenge.domain.models.Rover
 import com.adrifernandev.marsroverchallenge.domain.models.RoverInput
 
 fun RoverInstructionsDTO.toDomain(): RoverInput {
-    return RoverInput(
-        plateau = this.topRightCorner.toPlateau(),
-        initialRover = toRover(this.roverPosition, this.roverDirection),
-        instructions = Instructions.fromString(this.movements)
-    )
+    return try {
+        RoverInput(
+            plateau = this.topRightCorner.toPlateau(),
+            initialRover = toRover(this.roverPosition, this.roverDirection),
+            instructions = Instructions.fromString(this.movements)
+        )
+    } catch (e: IllegalArgumentException) {
+        throw IllegalArgumentException("Error while mapping to domain model: ${e.message}")
+    }
 }
 
 fun PositionDTO.toPlateau(): Plateau {

--- a/data/src/main/java/com/adrifernandev/marsroverchallenge/data/repository/RoverRepositoryImpl.kt
+++ b/data/src/main/java/com/adrifernandev/marsroverchallenge/data/repository/RoverRepositoryImpl.kt
@@ -18,11 +18,12 @@ class RoverRepositoryImpl @Inject constructor(
             .collectLatest { roverInputResult ->
                 roverInputResult.fold(
                     onSuccess = { roverInput ->
-                        send(
-                            Result.success(
-                                roverInput.toDomain()
-                            )
-                        )
+                        try {
+                            val roverInputDomain = roverInput.toDomain()
+                            send(Result.success(roverInputDomain))
+                        } catch (e: IllegalArgumentException) {
+                            send(Result.failure(e))
+                        }
                     },
                     onFailure = { error ->
                         send(Result.failure(error))

--- a/domain/src/main/java/com/adrifernandev/marsroverchallenge/domain/models/Instruction.kt
+++ b/domain/src/main/java/com/adrifernandev/marsroverchallenge/domain/models/Instruction.kt
@@ -20,7 +20,15 @@ sealed class Instruction {
 data class Instructions(val commands: List<Instruction>) {
     companion object {
         fun fromString(instructions: String): Instructions {
-            return Instructions(instructions.map { Instruction.fromChar(it) })
+            val validInstructions = mutableListOf<Instruction>()
+            instructions.forEach { char ->
+                try {
+                    validInstructions.add(Instruction.fromChar(char))
+                } catch (e: IllegalArgumentException) {
+                    throw e
+                }
+            }
+            return Instructions(validInstructions)
         }
     }
 }


### PR DESCRIPTION
Close #24 

This pull request introduces error handling to various parts of the code to ensure robustness when dealing with invalid input data. The most significant changes include adding try-catch blocks to handle `IllegalArgumentException` in several methods and updating the `RoverRepositoryImpl` to manage exceptions effectively.

Error handling improvements:

* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/datasource/remote/service/generator/RoverDataGenerator.kt`](diffhunk://#diff-130a697d6b869b901df1f2924eab4e0a61f60b8731ff4ecd99c3c6b8f8494211R12): Added a try-catch block to the `generateRandomRoverInputJson` method to handle `IllegalArgumentException` and throw a more descriptive error message. [[1]](diffhunk://#diff-130a697d6b869b901df1f2924eab4e0a61f60b8731ff4ecd99c3c6b8f8494211R12) [[2]](diffhunk://#diff-130a697d6b869b901df1f2924eab4e0a61f60b8731ff4ecd99c3c6b8f8494211R34-R36)
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/mapper/RoverMapper.kt`](diffhunk://#diff-c7a82831f183dfa6ac5c6c754ddad2343d1635d473f82e49bce180068ec69e6eL13-R21): Wrapped the mapping logic in `RoverInstructionsDTO.toDomain` with a try-catch block to catch `IllegalArgumentException` and provide a detailed error message.
* [`data/src/main/java/com/adrifernandev/marsroverchallenge/data/repository/RoverRepositoryImpl.kt`](diffhunk://#diff-f5ee8c02868974f7ec37d65144b4bf6718dbf0996b30252aa3d9a26a1f2de374L21-R26): Updated the `collectLatest` block to include a try-catch mechanism for converting `roverInput` to its domain model, sending a failure result if an exception occurs.
* [`domain/src/main/java/com/adrifernandev/marsroverchallenge/domain/models/Instruction.kt`](diffhunk://#diff-da1de9289b846e44e4adbb4cee0a7c87c6a35aa2aff2b30aff5a45a23a6e68acL23-R31): Modified the `fromString` method in `Instructions` to iterate through each character and handle invalid instructions by throwing an `IllegalArgumentException`.