### PR TITLE
[26] [feat] Create and config debug and release build types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,3 +303,4 @@ obj/
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/android,androidstudio,intellij,kotlin,java
+/app/signing/marsKeystore

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,16 +22,30 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        getByName("debug")
+        create("release") {
+            storeFile = file("signing/marsKeystore")
+            storePassword = System.getenv("MARS_ANDROID_KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("MARS_ANDROID_KEYSTORE_ALIAS")
+            keyPassword = System.getenv("MARS_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
         }
         debug {
-
+            signingConfig = signingConfigs.getByName("debug")
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
         }
     }
     compileOptions {


### PR DESCRIPTION
Close #26 

This pull request includes changes to the `app/build.gradle.kts` file to enhance the build configuration for the Android project. The most important changes include adding signing configurations for debug and release builds, enabling resource shrinking for release builds, and adding suffixes to the debug build's application ID and version name.

Build configuration improvements:

* Added `signingConfigs` block to define signing configurations for debug and release builds, including using environment variables for sensitive information.
* Enabled resource shrinking in the release build by setting `isShrinkResources` to `true`.
* Updated the release build type to use the release signing configuration.
* Updated the debug build type to use the debug signing configuration, and added `applicationIdSuffix` and `versionNameSuffix` for better differentiation of debug builds.