### PR TITLE
[11] [feat] Implement ktlint pre-commit hook

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,39 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.com.google.devtools.ksp) apply false
     alias(libs.plugins.com.google.dagger.hilt.android) apply false
+    alias(libs.plugins.ktlint)
+}
+
+tasks.register<Copy>("copyPreCommitHook") {
+    description = "Copy pre-commit git hook from the scripts to the .git/hooks folder."
+    group = "git hooks"
+    outputs.upToDateWhen { false }
+    from("$rootDir/hooks/pre-commit")
+    into("$rootDir/.git/hooks/")
+}
+
+val isWindows = org.gradle.internal.os.OperatingSystem.current().isWindows
+
+tasks.register("setExecutableGitHooks", Exec::class.java) {
+    description = "Sets executable permission on git hooks."
+    group = "git hooks"
+    if (isWindows) {
+        commandLine("cmd", "/c", "attrib", "+x", "$rootDir\\.git\\hooks\\*")
+    } else {
+        commandLine("chmod", "-R", "+x", "$rootDir/.git/hooks/")
+    }
+    dependsOn("copyPreCommitHook")
+}
+
+tasks.register("installGitHooks") {
+    description = "Installs the pre-commit git hooks from /git-hooks."
+    group = "git hooks"
+    dependsOn("copyPreCommitHook", "setExecutableGitHooks")
+    doLast {
+        logger.info("Git hooks installed successfully.")
+    }
+}
+
+afterEvaluate {
+    tasks.getByPath(":app:preBuild").dependsOn(":installGitHooks")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ ksp = "2.0.20-1.0.24"
 kotlinxCoroutinesTest = "1.8.1"
 turbine = "1.1.0"
 gson = "2.10.1"
+ktlint = "12.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -70,6 +71,7 @@ kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 com-google-dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 com-google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
 [bundles]
 layer-presentation = [

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Running git pre-commit hook"
+
+./gradlew ktlintCheck
+
+ktlintCheckStatus=$?
+
+if [[ $ktlintCheckStatus -ne 0 ]]; then
+     exit 1
+else
+     exit 0
+fi


### PR DESCRIPTION
Close #11 

This pull request includes updates to the dependencies and the addition of a pre-commit hook to enforce code style checks using ktlint. The most important changes include adding the ktlint dependency and configuring a pre-commit hook to run ktlint checks before commits.

Dependency updates:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR27): Added `ktlint` version `12.2.0` to the dependencies.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR74): Added `ktlint` plugin configuration with the appropriate version reference.

Pre-commit hook:

* [`hooks/pre-commit`](diffhunk://#diff-af9f2ce04299ecbb01b74030aa99f4343d08860e8dbddcabe77426e46379d025R1-R13): Added a new pre-commit hook script to run `ktlintCheck` and enforce code style checks before commits.